### PR TITLE
Revert "build: Enable custom ccache cache dir for Android"

### DIFF
--- a/core/ccache.mk
+++ b/core/ccache.mk
@@ -55,12 +55,6 @@ ifneq ($(filter-out false,$(USE_CCACHE)),)
     ifndef CXX_WRAPPER
       CXX_WRAPPER := $(ccache)
     endif
-    ifeq ($(ANDROID_CCACHE_DIR), $(CCACHE_DIR))
-      ifneq ($(ANDROID_CCACHE_SIZE),)
-        ACCSIZE_RESULT := $(shell $(ccache) -M$(ANDROID_CCACHE_SIZE))
-      endif
-    endif
     ccache =
-    ACCSIZE_RESULT =
   endif
 endif

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -276,10 +276,6 @@ function setpaths()
     unset ANDROID_HOST_OUT
     export ANDROID_HOST_OUT=$(get_abs_build_var HOST_OUT)
 
-    if [ -n "$ANDROID_CCACHE_DIR" ]; then
-        export CCACHE_DIR=$ANDROID_CCACHE_DIR
-    fi
-
     # needed for building linux on MacOS
     # TODO: fix the path
     #export HOST_EXTRACFLAGS="-I "$T/system/kernel_headers/host_include


### PR DESCRIPTION
Developers can specify ccache parameters by sourcing a personal build
environment script before envsetup. For example:

  CMHOME=$HOME/android/cm
  export USE_CCACHE=1
  export CCACHE_DIR=$CMHOME/.ccache
  $CMHOME/prebuilts/misc/linux-x86/ccache/ccache -M50G
  # Maybe someday, currently not supported in ccache 3.1.x
  # echo "max_size = 50G" > "$CCACHE_DIR/ccache.conf"

This reverts commit d99981e6f2576d5fcce8bc5f6255407184b2de16.

Change-Id: Ic7b36a6d61269647aec022a86570cfa2068f65d7